### PR TITLE
refactor: Move Makefile to root directory for monorepo structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ help:
 
 .PHONY: fmt
 fmt: ## Run go fmt
-	go fmt ./...
+	cd backend && go fmt ./...
 
 .PHONY: up
 up: ## Run docker-compose up
-	docker compose up -d
+	docker compose -f infrastructure/docker-compose.yaml up -d
 	
 .PHONY: down
 down: ## Run docker-compose down
-	docker compose down
+	docker compose -f infrastructure/docker-compose.yaml down


### PR DESCRIPTION
## Summary
- Moved Makefile from backend/ to project root to better support monorepo structure
- Updated all paths in Makefile to work correctly from the root directory

## Changes
- Moved `backend/Makefile` to root directory
- Updated `fmt` command to use `cd backend && go fmt ./...`
- Updated `up` and `down` commands to reference `infrastructure/docker-compose.yaml`

## Test plan
- [x] Verified `make help` displays all commands correctly
- [x] Verified `make fmt` changes to backend directory before running go fmt
- [x] Verified `make up` starts containers using the correct docker-compose file
- [x] Verified `make down` stops containers using the correct docker-compose file

🤖 Generated with [Claude Code](https://claude.ai/code)