### PR TITLE
chore(deps): bump golang.org/x/sync from 0.8.0 to 0.14.0

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,11 +1,11 @@
 module github.com/bayamasa/go-boilerplate
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/caarlos0/env/v11 v11.2.2
 	github.com/go-sql-driver/mysql v1.8.1
-	golang.org/x/sync v0.8.0
+	golang.org/x/sync v0.14.0
 )
 
 require filippo.io/edwards25519 v1.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -4,5 +4,5 @@ github.com/caarlos0/env/v11 v11.2.2 h1:95fApNrUyueipoZN/EhA8mMxiNxrBwDa+oAZrMWl3
 github.com/caarlos0/env/v11 v11.2.2/go.mod h1:JBfcdeQiBoI3Zh1QRAWfe+tpiNTmDtcCj/hHHHMx0vc=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=


### PR DESCRIPTION
## Summary
- Updates golang.org/x/sync from 0.8.0 to 0.14.0
- Updates Go version from 1.22.5 to 1.23.0
- Resolves the conflict from Dependabot PR #3 after the monorepo restructuring

## Context
This PR manually applies the updates from Dependabot PR #3, which had conflicts due to the recent monorepo restructuring where `go.mod` and `go.sum` were moved to the `backend/` directory.

## Test plan
- [x] Dependencies updated successfully with `go mod download` and `go mod tidy`
- [ ] CI/CD pipeline passes
- [ ] Application builds and runs correctly

🤖 Generated with [Claude Code](https://claude.ai/code)