### PR TITLE
fix: Update Go version from 1.22.5 to 1.23.0 in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.22.5
+ARG GO_VERSION=1.23.0
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS base
 WORKDIR /src
 


### PR DESCRIPTION
## Summary
- Updated the base Go version in the backend Dockerfile from 1.22.5 to 1.23.0
- This change aligns with the requirement specified in go.mod (go 1.23.0)
- Resolves the build error: "go.mod requires go >= 1.23.0 (running go 1.22.5)"

## Test plan
- [x] Docker build completes successfully
- [x] Docker containers start without errors
- [x] Health check endpoint (/healthz) returns 200 OK

🤖 Generated with [Claude Code](https://claude.ai/code)