### PR TITLE
feat: バックエンド全エンドポイントのインテグレーションテスト追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,8 @@ lint-fix: ## Run Biome lint check and fix
 format: ## Run Biome format
 	pnpm --filter frontend format
 	pnpm --filter backend exec biome format --write .
+
+# Test commands
+.PHONY: endpoint-test
+endpoint-test: ## Run backend integration tests
+	pnpm test:integration

--- a/backend/jest.config.integration.ts
+++ b/backend/jest.config.integration.ts
@@ -3,12 +3,12 @@ import type { Config } from 'jest'
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src', '<rootDir>/tests'],
-  testMatch: ['**/*.test.ts', '**/tests/**/*.ts'],
-  setupFiles: ['<rootDir>/src/__tests__/setup.ts'],
+  roots: ['<rootDir>/tests/integration'],
+  testMatch: ['**/tests/integration/**/*.test.ts'],
+  setupFiles: ['<rootDir>/tests/integration/setup/jestSetup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '^@db/index$': '<rootDir>/src/__mocks__/dbMock.ts',
+    '^@db/index$': '<rootDir>/../db/index.ts',
     '^@db/schema$': '<rootDir>/../db/schema.ts',
     '^@trippers/shared$': '<rootDir>/../shared/src',
     '^@trippers/shared/(.*)$': '<rootDir>/../shared/src/$1',
@@ -23,6 +23,9 @@ const config: Config = {
   },
   extensionsToTreatAsEsm: ['.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testTimeout: 30000,
+  globalSetup: '<rootDir>/tests/integration/setup/globalSetup.ts',
+  globalTeardown: '<rootDir>/tests/integration/setup/globalTeardown.ts',
 }
 
 export default config

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "start": "$HOME/.volta/bin/bun run dist/index.js",
     "lint": "biome check .",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
-    "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch"
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch",
+    "test:integration": "NODE_OPTIONS='--experimental-vm-modules' jest --config jest.config.integration.ts --runInBand --forceExit"
   },
   "dependencies": {
     "@hono/swagger-ui": "^0.5.3",
@@ -24,9 +25,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
+    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "^1.2.5",
     "@types/jest": "^30.0.0",
     "@types/pg": "^8.16.0",
+    "bcryptjs": "^3.0.3",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/backend/tests/integration/helpers/auth.ts
+++ b/backend/tests/integration/helpers/auth.ts
@@ -1,0 +1,106 @@
+import type { OpenAPIHono } from '@hono/zod-openapi'
+import { eq } from 'drizzle-orm'
+import { userAuthTable } from '../../../../db/schema'
+import { getTestDb } from '../setup/testDb'
+
+export interface AuthResult {
+  userId: number
+  email: string
+  jwtToken: string
+}
+
+/**
+ * Performs the full signup -> verifyEmail flow and returns a JWT token.
+ * The verification token is read directly from the DB (stored as base64 of nanoid),
+ * then decoded to get the raw token to send to the verify-email endpoint.
+ */
+export async function signupAndVerify(
+  app: OpenAPIHono,
+  email: string,
+  password: string,
+): Promise<AuthResult> {
+  // 1. Signup
+  const signupRes = await app.request('/v1/auth/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+
+  if (signupRes.status !== 201) {
+    const body = await signupRes.json()
+    throw new Error(
+      `Signup failed with status ${signupRes.status}: ${JSON.stringify(body)}`,
+    )
+  }
+
+  const signupBody = (await signupRes.json()) as {
+    user: { id: number; email: string }
+  }
+  const userId = signupBody.user.id
+
+  // 2. Read the hashed token from DB and decode to get raw token
+  const db = getTestDb()
+  const [userRecord] = await db
+    .select({ emailVerificationToken: userAuthTable.emailVerificationToken })
+    .from(userAuthTable)
+    .where(eq(userAuthTable.id, userId))
+    .limit(1)
+
+  if (!userRecord?.emailVerificationToken) {
+    throw new Error('Email verification token not found in DB')
+  }
+
+  // The hashed token is Buffer.from(rawToken).toString('base64')
+  // So to recover rawToken: Buffer.from(hashedToken, 'base64').toString('utf-8')
+  const rawToken = Buffer.from(
+    userRecord.emailVerificationToken,
+    'base64',
+  ).toString('utf-8')
+
+  // 3. Verify email
+  const verifyRes = await app.request('/v1/auth/verify-email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: rawToken }),
+  })
+
+  if (verifyRes.status !== 200) {
+    const body = await verifyRes.json()
+    throw new Error(
+      `Email verification failed with status ${verifyRes.status}: ${JSON.stringify(body)}`,
+    )
+  }
+
+  const verifyBody = (await verifyRes.json()) as { token: string }
+
+  return {
+    userId,
+    email,
+    jwtToken: verifyBody.token,
+  }
+}
+
+/**
+ * Performs login and returns the JWT token.
+ */
+export async function login(
+  app: OpenAPIHono,
+  email: string,
+  password: string,
+): Promise<string> {
+  const res = await app.request('/v1/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+
+  if (res.status !== 200) {
+    const body = await res.json()
+    throw new Error(
+      `Login failed with status ${res.status}: ${JSON.stringify(body)}`,
+    )
+  }
+
+  const body = (await res.json()) as { token: string }
+  return body.token
+}

--- a/backend/tests/integration/routes/auth.test.ts
+++ b/backend/tests/integration/routes/auth.test.ts
@@ -1,0 +1,84 @@
+import { createApp } from '../../../src/app'
+import { signupAndVerify } from '../helpers/auth'
+import { cleanupUserByEmail } from '../setup/testDb'
+
+const app = createApp()
+
+const TEST_EMAIL = 'integration-auth-test@example.com'
+const TEST_PASSWORD = 'Password123!'
+
+afterAll(async () => {
+  await cleanupUserByEmail(TEST_EMAIL)
+})
+
+describe('Auth API - Integration', () => {
+  describe('POST /v1/auth/signup', () => {
+    it('should register a new user and return 201', async () => {
+      const res = await app.request('/v1/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+      })
+
+      expect(res.status).toBe(201)
+
+      const json = (await res.json()) as {
+        message: string
+        user: { id: number; email: string }
+      }
+      expect(json.message).toBeDefined()
+      expect(json.user.email).toBe(TEST_EMAIL)
+      expect(typeof json.user.id).toBe('number')
+    })
+  })
+
+  describe('POST /v1/auth/verify-email', () => {
+    it('should verify email with valid token and return JWT', async () => {
+      // The signup already happened in the previous test, so we read the token from DB
+      // We use signupAndVerify for a fresh flow in a separate test email
+      const verifyEmail = 'integration-verify-test@example.com'
+
+      try {
+        const result = await signupAndVerify(app, verifyEmail, TEST_PASSWORD)
+
+        expect(result.jwtToken).toBeDefined()
+        expect(typeof result.jwtToken).toBe('string')
+        expect(result.jwtToken.length).toBeGreaterThan(0)
+      } finally {
+        await cleanupUserByEmail(verifyEmail)
+      }
+    })
+  })
+
+  describe('POST /v1/auth/login', () => {
+    it('should login verified user and return JWT token', async () => {
+      // Use a dedicated email for login test to avoid state dependency
+      const loginEmail = 'integration-login-test@example.com'
+
+      try {
+        // First sign up and verify
+        await signupAndVerify(app, loginEmail, TEST_PASSWORD)
+
+        // Then login
+        const res = await app.request('/v1/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: loginEmail, password: TEST_PASSWORD }),
+        })
+
+        expect(res.status).toBe(200)
+
+        const json = (await res.json()) as {
+          user: { id: number; email: string; emailVerified: boolean }
+          token: string
+        }
+        expect(json.user.email).toBe(loginEmail)
+        expect(json.user.emailVerified).toBe(true)
+        expect(typeof json.token).toBe('string')
+        expect(json.token.length).toBeGreaterThan(0)
+      } finally {
+        await cleanupUserByEmail(loginEmail)
+      }
+    })
+  })
+})

--- a/backend/tests/integration/routes/destinations.test.ts
+++ b/backend/tests/integration/routes/destinations.test.ts
@@ -1,0 +1,65 @@
+import { createApp } from '../../../src/app'
+
+const app = createApp()
+
+describe('Destinations API - Integration', () => {
+  describe('GET /v1/destinations/:destination_slug/tours', () => {
+    it('should return tours for a valid destination slug (bali)', async () => {
+      const res = await app.request('/v1/destinations/bali/tours')
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as Array<{
+        tour: {
+          id: number
+          title: string
+          minPriceTaxIncluded: number
+          departsAirportId: number
+          days: number
+          isDirectFlight: boolean
+          airlinesId: number
+          hotelId: number
+          thumbnailFileName: string
+        }
+        destination: {
+          id: number
+          slug: string
+          nameJp: string
+          imageFilename: string
+        }
+        area: {
+          name: string
+          nameJp: string
+        }
+        stock: {
+          id: number
+          tourId: number
+          eventStartDate: string
+          maxCapacity: number
+          availableCapacity: number
+          createdAt: string
+        }
+      }>
+
+      expect(Array.isArray(json)).toBe(true)
+      expect(json.length).toBeGreaterThan(0)
+
+      const firstItem = json[0]
+      expect(firstItem.tour).toBeDefined()
+      expect(firstItem.destination).toBeDefined()
+      expect(firstItem.area).toBeDefined()
+      expect(firstItem.stock).toBeDefined()
+
+      // All results should be for 'bali'
+      for (const item of json) {
+        expect(item.destination.slug).toBe('bali')
+      }
+
+      expect(typeof firstItem.stock.id).toBe('number')
+      expect(typeof firstItem.stock.eventStartDate).toBe('string')
+      expect(typeof firstItem.stock.maxCapacity).toBe('number')
+      expect(typeof firstItem.stock.availableCapacity).toBe('number')
+      expect(typeof firstItem.stock.createdAt).toBe('string')
+    })
+  })
+})

--- a/backend/tests/integration/routes/health.test.ts
+++ b/backend/tests/integration/routes/health.test.ts
@@ -1,0 +1,18 @@
+import { createApp } from '../../../src/app'
+
+const app = createApp()
+
+describe('Health API - Integration', () => {
+  describe('GET /health', () => {
+    it('should return status ok with timestamp', async () => {
+      const res = await app.request('/health')
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as { status: string; timestamp: string }
+      expect(json.status).toBe('ok')
+      expect(json.timestamp).toBeDefined()
+      expect(typeof json.timestamp).toBe('string')
+    })
+  })
+})

--- a/backend/tests/integration/routes/tours.test.ts
+++ b/backend/tests/integration/routes/tours.test.ts
@@ -1,0 +1,50 @@
+import { createApp } from '../../../src/app'
+
+const app = createApp()
+
+describe('Tours API - Integration', () => {
+  describe('GET /v1/tours', () => {
+    it('should return an array of tours with seed data', async () => {
+      const res = await app.request('/v1/tours')
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as Array<{
+        tour: {
+          id: number
+          title: string
+          minPriceTaxIncluded: number
+          departsAirportId: number
+          days: number
+          isDirectFlight: boolean
+          airlinesId: number
+          hotelId: number
+          thumbnailFileName: string
+        }
+        destination: {
+          id: number
+          slug: string
+          nameJp: string
+          imageFilename: string
+        }
+        area: {
+          name: string
+          nameJp: string
+        }
+      }>
+
+      expect(Array.isArray(json)).toBe(true)
+      expect(json.length).toBeGreaterThan(0)
+
+      const firstTour = json[0]
+      expect(firstTour.tour).toBeDefined()
+      expect(firstTour.destination).toBeDefined()
+      expect(firstTour.area).toBeDefined()
+      expect(typeof firstTour.tour.id).toBe('number')
+      expect(typeof firstTour.tour.title).toBe('string')
+      expect(typeof firstTour.tour.minPriceTaxIncluded).toBe('number')
+      expect(typeof firstTour.destination.slug).toBe('string')
+      expect(typeof firstTour.area.name).toBe('string')
+    })
+  })
+})

--- a/backend/tests/integration/routes/users.test.ts
+++ b/backend/tests/integration/routes/users.test.ts
@@ -1,0 +1,129 @@
+import { createApp } from '../../../src/app'
+import { signupAndVerify } from '../helpers/auth'
+import { cleanupUserByEmail } from '../setup/testDb'
+
+const app = createApp()
+
+const TEST_EMAIL = 'integration-users-test@example.com'
+const TEST_PASSWORD = 'Password123!'
+
+let jwtToken: string
+
+beforeAll(async () => {
+  const result = await signupAndVerify(app, TEST_EMAIL, TEST_PASSWORD)
+  jwtToken = result.jwtToken
+})
+
+afterAll(async () => {
+  await cleanupUserByEmail(TEST_EMAIL)
+})
+
+describe('Users API - Integration', () => {
+  describe('GET /v1/users/me', () => {
+    it('should return current user info with valid JWT', async () => {
+      const res = await app.request('/v1/users/me', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${jwtToken}`,
+        },
+      })
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as {
+        id: number
+        email: string
+        emailVerified: boolean
+        profileCompleted: boolean
+        profile: null | object
+      }
+      expect(json.email).toBe(TEST_EMAIL)
+      expect(json.emailVerified).toBe(true)
+      expect(json.profileCompleted).toBe(false)
+      expect(json.profile).toBeNull()
+    })
+
+    it('should return 401 without Authorization header', async () => {
+      const res = await app.request('/v1/users/me', {
+        method: 'GET',
+      })
+
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('POST /v1/users/me/profile', () => {
+    it('should create a user profile and return 201', async () => {
+      const profileData = {
+        lastName: 'テスト',
+        firstName: '太郎',
+        gender: 'male',
+        dateOfBirth: '1990-01-15',
+        location: '東京都',
+      }
+
+      const res = await app.request('/v1/users/me/profile', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${jwtToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(profileData),
+      })
+
+      expect(res.status).toBe(201)
+
+      const json = (await res.json()) as { message: string }
+      expect(json.message).toBeDefined()
+    })
+  })
+
+  describe('PATCH /v1/users/me/profile', () => {
+    it('should update an existing user profile and return 200', async () => {
+      const updateData = {
+        firstName: '次郎',
+        location: '大阪府',
+      }
+
+      const res = await app.request('/v1/users/me/profile', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${jwtToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updateData),
+      })
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as { message: string }
+      expect(json.message).toBeDefined()
+    })
+
+    it('should reflect updated profile in GET /v1/users/me', async () => {
+      const res = await app.request('/v1/users/me', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${jwtToken}`,
+        },
+      })
+
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as {
+        profileCompleted: boolean
+        profile: {
+          lastName: string
+          firstName: string
+          gender: string
+          dateOfBirth: string
+          location: string
+        } | null
+      }
+      expect(json.profileCompleted).toBe(true)
+      expect(json.profile).not.toBeNull()
+      expect(json.profile?.firstName).toBe('次郎')
+      expect(json.profile?.location).toBe('大阪府')
+    })
+  })
+})

--- a/backend/tests/integration/setup/globalSetup.ts
+++ b/backend/tests/integration/setup/globalSetup.ts
@@ -1,0 +1,23 @@
+import { Pool } from 'pg'
+
+export default async function globalSetup(): Promise<void> {
+  const databaseUrl =
+    process.env.DATABASE_URL ||
+    'postgresql://trippers:trippers@localhost:5432/trippers'
+
+  const pool = new Pool({ connectionString: databaseUrl })
+
+  try {
+    const client = await pool.connect()
+    await client.query('SELECT 1')
+    client.release()
+    console.log('Database connection confirmed for integration tests')
+  } catch (error) {
+    console.error('Failed to connect to database:', error)
+    throw new Error(
+      'Integration tests require a running PostgreSQL database. Please run: docker compose up -d',
+    )
+  } finally {
+    await pool.end()
+  }
+}

--- a/backend/tests/integration/setup/globalTeardown.ts
+++ b/backend/tests/integration/setup/globalTeardown.ts
@@ -1,0 +1,11 @@
+export default async function globalTeardown(): Promise<void> {
+  // Per-test cleanup is handled in individual test files' afterAll hooks.
+  // Close the shared test DB pool used by testDb.ts helpers.
+  try {
+    const { closeTestDb } = await import('./testDb')
+    await closeTestDb()
+  } catch {
+    // ignore if not connected
+  }
+  console.log('Integration test suite completed')
+}

--- a/backend/tests/integration/setup/jestSetup.ts
+++ b/backend/tests/integration/setup/jestSetup.ts
@@ -1,0 +1,26 @@
+import bcryptjs from 'bcryptjs'
+
+// Polyfill Bun.password for Jest/Node.js environment
+// The backend services use Bun.password.hash and Bun.password.verify
+// which are not available in Node.js. We replace them with bcryptjs equivalents.
+globalThis.Bun = {
+  ...((globalThis as unknown as { Bun?: Record<string, unknown> }).Bun || {}),
+  password: {
+    hash: async (
+      password: string,
+      options?: { algorithm?: string; cost?: number },
+    ): Promise<string> => {
+      const cost = options?.cost ?? 10
+      return bcryptjs.hash(password, cost)
+    },
+    verify: async (password: string, hash: string): Promise<boolean> => {
+      return bcryptjs.compare(password, hash)
+    },
+  },
+} as typeof Bun
+
+// Set test environment
+process.env.NODE_ENV = 'test'
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  'postgresql://trippers:trippers@localhost:5432/trippers'

--- a/backend/tests/integration/setup/testDb.ts
+++ b/backend/tests/integration/setup/testDb.ts
@@ -1,0 +1,40 @@
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
+import * as schema from '../../../../db/schema'
+import { userAuthTable } from '../../../../db/schema'
+
+const databaseUrl =
+  process.env.DATABASE_URL ||
+  'postgresql://trippers:trippers@localhost:5432/trippers'
+
+let pool: Pool | undefined
+
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool({
+      connectionString: databaseUrl,
+      max: 5,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+    })
+  }
+  return pool
+}
+
+export function getTestDb() {
+  return drizzle({ client: getPool(), schema })
+}
+
+export async function cleanupUserByEmail(email: string): Promise<void> {
+  const db = getTestDb()
+  // user_profiles is deleted via ON DELETE CASCADE when user_auth is deleted
+  await db.delete(userAuthTable).where(eq(userAuthTable.email, email))
+}
+
+export async function closeTestDb(): Promise<void> {
+  if (pool) {
+    await pool.end()
+    pool = undefined
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -22,6 +22,6 @@
       "@trippers/shared/*": ["./shared/src/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:migrate": "drizzle-kit migrate --config db/drizzle.config.ts",
     "db:studio": "drizzle-kit studio --config db/drizzle.config.ts",
     "db:seed": "tsx db/seed.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:integration": "pnpm --filter backend test:integration"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.8
         version: 2.3.8
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/bun':
         specifier: ^1.2.5
         version: 1.3.5
@@ -91,6 +94,9 @@ importers:
       '@types/pg':
         specifier: ^8.16.0
         version: 8.16.0
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       jest:
         specifier: ^30.2.0
         version: 30.2.0(@types/node@24.10.4)(esbuild-register@3.6.0(esbuild@0.27.2))(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3))
@@ -2259,6 +2265,10 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
+
   '@types/bun@1.3.5':
     resolution: {integrity: sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w==}
 
@@ -2539,6 +2549,10 @@ packages:
 
   baseline-browser-mapping@2.9.7:
     resolution: {integrity: sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==}
+    hasBin: true
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
   brace-expansion@1.1.12:
@@ -5940,6 +5954,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
+
   '@types/bun@1.3.5':
     dependencies:
       bun-types: 1.3.5
@@ -6183,6 +6201,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.7: {}
+
+  bcryptjs@3.0.3: {}
 
   brace-expansion@1.1.12:
     dependencies:


### PR DESCRIPTION
## Summary

- 全バックエンド API エンドポイント（health / auth / users / tours / destinations）の正常系インテグレーションテストを追加
- `backend/tests/integration/` にテストスイートを配置（Jest + 実 PostgreSQL）
- `Bun.password` の Node.js 互換ポリフィル（bcryptjs）を実装
- `make endpoint-test` / `pnpm test:integration` でテスト実行可能

## Test plan

- [ ] `docker compose up -d` で DB を起動
- [ ] `pnpm db:seed` でシードデータを投入
- [ ] `make endpoint-test` を実行して全 11 テストが PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)